### PR TITLE
Update how appsettings are used.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,6 @@ FodyWeavers.xsd
 
 #Rider Stuff
 .idea
+
+# Mac Stuff
+.DS_Store

--- a/Blazor.KubeXTerm.Demo/Program.cs
+++ b/Blazor.KubeXTerm.Demo/Program.cs
@@ -15,7 +15,6 @@ var builder = WebApplication.CreateBuilder(args);
 // Load configuration from appsettings.json & environment variables
 var configuration = builder.Configuration.SetBasePath(Directory.GetCurrentDirectory())
     .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true) // Load appsettings.json
-    .AddJsonFile("appsettings.Development.json", optional: true, reloadOnChange: true) // Load appsettings.Development.json
     .AddEnvironmentVariables() // Override with environment variables if set
     .Build();
 

--- a/Blazor.KubeXTerm.Demo/appsettings.Development.json
+++ b/Blazor.KubeXTerm.Demo/appsettings.Development.json
@@ -5,15 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "ASPNETCORE_URLS": "http://+:80",
-  "LOGGING__LOGLEVEL__DEFAULT": "Trace",
-  "LOGGING__LOGLEVEL__MICROSOFT": "Warning",
-
-  "OIDC_IDP_ADDRESS_FOR_SERVER": "https://kc.freemancraft.com/realms/kubexterm",
-  "OIDC_IDP_ADDRESS_FOR_USERS": "https://kc.freemancraft.com/realms/kubexterm",
-  "OIDC_CLIENT_ID": "kube_xterm_demo",
-  "OIDC_REQUIRE_HTTPS_METADATA": "false",
-  "USE_KEYCLOAK": "true",
-  "HTTPCLIENT_VALIDATE_EXTERNAL_CERTIFICATES": "true",
-  "OIDC_LOGOUT_REDIRECT_URI": "https://localhost:44317"
+  "USE_KEYCLOAK": "false",
+  "HTTPCLIENT_VALIDATE_EXTERNAL_CERTIFICATES": "false"
 }

--- a/Blazor.KubeXTerm.Demo/appsettings.json
+++ b/Blazor.KubeXTerm.Demo/appsettings.json
@@ -5,5 +5,20 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  
+  "ASPNETCORE_URLS": "http://+:80",
+  
+  "LOGGING__LOGLEVEL__DEFAULT": "Trace",
+  "LOGGING__LOGLEVEL__MICROSOFT": "Warning",
+
+  "OIDC_IDP_ADDRESS_FOR_SERVER": "https://kc.freemancraft.com/realms/kubexterm",
+  "OIDC_IDP_ADDRESS_FOR_USERS": "https://kc.freemancraft.com/realms/kubexterm",
+  "OIDC_CLIENT_ID": "kube_xterm_demo",
+  "OIDC_REQUIRE_HTTPS_METADATA": "false",
+  "OIDC_LOGOUT_REDIRECT_URI": "https://localhost:44317",
+  
+  "USE_KEYCLOAK": "true",
+  "HTTPCLIENT_VALIDATE_EXTERNAL_CERTIFICATES": "true"
+  
 }


### PR DESCRIPTION
* Move all the existing settings to `appsettings.json`
* Change development default values for USE_KEYCLOAK and HTTPCLIENT_VALIDATE_EXTERNAL_CERTIFICATES to be least restrictive. 
* Remove line that adds `appsettings.Development.json` to the configuration. (dotnet handles this)